### PR TITLE
refactor: apply spatial index

### DIFF
--- a/backend/demo/build.gradle
+++ b/backend/demo/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.hibernate.orm:hibernate-spatial:6.1.7.Final'
     implementation 'org.hibernate.orm:hibernate-core:6.0.2.Final'
+    implementation 'org.hibernate:hibernate-jcache:6.0.2.Final' // Cache API
+    implementation 'org.ehcache:ehcache:3.10.8'                 // Cache implementation
     implementation 'org.hibernate.search:hibernate-search-mapper-orm-orm6:6.1.7.Final'
     implementation 'org.hibernate.search:hibernate-search-backend-lucene:6.1.7.Final'
     implementation 'org.hibernate.search:hibernate-search-backend-elasticsearch:6.1.7.Final'
@@ -52,10 +54,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-    implementation "com.querydsl:querydsl-sql-spatial:5.0.0"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-spatial:5.0.0"
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.orbisgis:h2gis:2.1.0'

--- a/backend/demo/src/main/java/com/_2cha/demo/collection/controller/CollectionController.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/collection/controller/CollectionController.java
@@ -74,9 +74,10 @@ public class CollectionController {
   @Auth(MEMBER)
   @GetMapping("/collections/nearby")
   public List<CollectionBriefResponse> nbCollection(
+      @RequestParam(name = "max_dist", required = false, defaultValue = "1000.0") Double maxDist,
       @RequestParam Double lat,
       @RequestParam Double lon) {
-    return collectionService.getNearbyCollections(lat, lon, 1000.0);
+    return collectionService.getNearbyCollections(lat, lon, maxDist);
   }
 
   @Auth(GUEST)

--- a/backend/demo/src/main/java/com/_2cha/demo/collection/repository/CollectionQueryRepository.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/collection/repository/CollectionQueryRepository.java
@@ -17,7 +17,8 @@ import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.locationtech.jts.geom.Point;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -76,7 +77,7 @@ public class CollectionQueryRepository {
   }
 
   // get place count of each collection, that is within `distance` m from the given location
-  public Map<Long, Long> getNearbyPlaceCount(Point location, Double distance) {
+  public Map<Long, Long> getNearbyPlaceCount(Point<G2D> location, Double distance) {
 
     NumberTemplate<Double> distanceSphere = Expressions.numberTemplate(Double.class,
                                                                        "function('ST_DistanceSphere', {0}, {1})",

--- a/backend/demo/src/main/java/com/_2cha/demo/place/domain/Place.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/place/domain/Place.java
@@ -10,7 +10,8 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.locationtech.jts.geom.Point;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
 
 @Entity
 @Getter
@@ -36,8 +37,8 @@ public class Place {
   @Column
   private String lotAddress;
 
-  @Column(nullable = false, columnDefinition = "geometry(point,  4326)") // long, lat
-  private Point location;
+  @Column(nullable = false, columnDefinition = "geography(point,  4326)") // long, lat
+  private Point<G2D> location;
 
 
   @Enumerated(EnumType.STRING)

--- a/backend/demo/src/main/java/com/_2cha/demo/place/dto/PlaceCreatedResponse.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/place/dto/PlaceCreatedResponse.java
@@ -2,6 +2,7 @@ package com._2cha.demo.place.dto;
 
 import com._2cha.demo.place.domain.Category;
 import com._2cha.demo.place.domain.Place;
+import com._2cha.demo.util.GeomUtils;
 import lombok.Data;
 
 @Data
@@ -24,7 +25,7 @@ public class PlaceCreatedResponse {
     this.address = place.getAddress();
     this.lotAddress = place.getLotAddress();
     this.image = place.getImageUrlPath() != null ? baseUrl + place.getImageUrlPath() : null;
-    this.lat = place.getLocation().getY();
-    this.lon = place.getLocation().getX();
+    this.lat = GeomUtils.lat(place.getLocation());
+    this.lon = GeomUtils.lon(place.getLocation());
   }
 }

--- a/backend/demo/src/main/java/com/_2cha/demo/place/dto/PlaceDetailResponse.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/place/dto/PlaceDetailResponse.java
@@ -3,11 +3,13 @@ package com._2cha.demo.place.dto;
 import com._2cha.demo.bookmark.dto.BookmarkStatus;
 import com._2cha.demo.place.domain.Category;
 import com._2cha.demo.review.dto.TagCountResponse;
+import com._2cha.demo.util.GeomUtils;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.List;
 import lombok.Data;
-import org.locationtech.jts.geom.Point;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
 
 @Data
 public class PlaceDetailResponse {
@@ -28,7 +30,7 @@ public class PlaceDetailResponse {
 
   public PlaceDetailResponse(Long id, String name, Category category, String address,
                              String lotAddress,
-                             String imageUrl, String site, Point location) {
+                             String imageUrl, String site, Point<G2D> location) {
     this.id = id;
     this.name = name;
     this.category = category;
@@ -36,7 +38,7 @@ public class PlaceDetailResponse {
     this.address = address;
     this.image = imageUrl;
     this.site = site;
-    this.lat = location.getY();
-    this.lon = location.getX();
+    this.lat = GeomUtils.lat(location);
+    this.lon = GeomUtils.lon(location);
   }
 }

--- a/backend/demo/src/main/java/com/_2cha/demo/place/dto/PlaceFuzzySearchResponse.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/place/dto/PlaceFuzzySearchResponse.java
@@ -2,6 +2,7 @@ package com._2cha.demo.place.dto;
 
 import com._2cha.demo.place.domain.Category;
 import com._2cha.demo.place.domain.Place;
+import com._2cha.demo.util.GeomUtils;
 import java.util.List;
 import lombok.Data;
 
@@ -24,8 +25,8 @@ public class PlaceFuzzySearchResponse {
     this.address = place.getAddress();
     this.thumbnail =
         place.getThumbnailUrlPath() != null ? baseUrl + place.getThumbnailUrlPath() : null;
-    this.lon = place.getLocation().getX();
-    this.lat = place.getLocation().getY();
+    this.lon = GeomUtils.lon(place.getLocation());
+    this.lat = GeomUtils.lat(place.getLocation());
 
     this.matchingIndexes = matchingIndexes;
   }

--- a/backend/demo/src/main/java/com/_2cha/demo/place/repository/PlaceQueryRepository.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/place/repository/PlaceQueryRepository.java
@@ -29,7 +29,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.locationtech.jts.geom.Point;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Repository;
 
@@ -116,7 +117,7 @@ public class PlaceQueryRepository {
    * @param id
    * @return PlaceBriefWithDistanceResponse, without tagSummary
    */
-  public PlaceBriefWithDistanceResponse getPlaceBriefWithDistance(Long id, Point location,
+  public PlaceBriefWithDistanceResponse getPlaceBriefWithDistance(Long id, Point<G2D> location,
                                                                   String imgBaseUrl) {
     NumberTemplate<Double> distance = Expressions.numberTemplate(Double.class,
                                                                  "function('ST_DistanceSphere', {0}, {1})",

--- a/backend/demo/src/main/java/com/_2cha/demo/place/repository/PlaceQueryRepository.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/place/repository/PlaceQueryRepository.java
@@ -120,9 +120,10 @@ public class PlaceQueryRepository {
   public PlaceBriefWithDistanceResponse getPlaceBriefWithDistance(Long id, Point<G2D> location,
                                                                   String imgBaseUrl) {
     NumberTemplate<Double> distance = Expressions.numberTemplate(Double.class,
-                                                                 "function('ST_DistanceSphere', {0}, {1})",
+                                                                 "ST_Distance({0}, geography({1}))",
                                                                  place.location,
                                                                  location);
+    
     return queryFactory.select(constructor(PlaceBriefWithDistanceResponse.class,
                                            place.id,
                                            place.name,

--- a/backend/demo/src/main/java/com/_2cha/demo/place/repository/strategy/FilterSortContext.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/place/repository/strategy/FilterSortContext.java
@@ -12,7 +12,8 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.locationtech.jts.geom.Point;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
 
 @Slf4j
 public class FilterSortContext {
@@ -30,7 +31,7 @@ public class FilterSortContext {
     this.sortStrategy = sortStrategy;
   }
 
-  public List<Tuple> execute(Point location, Double maxDist,
+  public List<Tuple> execute(Point<G2D> location, Double maxDist,
                              Long offset, Integer pageSize,
                              List<?> filterValues, SortOrder sortOrder) {
     NumberTemplate<Double> distanceSphere = Expressions.numberTemplate(Double.class,

--- a/backend/demo/src/main/java/com/_2cha/demo/place/repository/strategy/FilterSortContext.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/place/repository/strategy/FilterSortContext.java
@@ -6,6 +6,7 @@ import com._2cha.demo.place.dto.SortOrder;
 import com._2cha.demo.place.repository.strategy.filter.FilterStrategy;
 import com._2cha.demo.place.repository.strategy.sort.SortStrategy;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanTemplate;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -34,15 +35,21 @@ public class FilterSortContext {
   public List<Tuple> execute(Point<G2D> location, Double maxDist,
                              Long offset, Integer pageSize,
                              List<?> filterValues, SortOrder sortOrder) {
-    NumberTemplate<Double> distanceSphere = Expressions.numberTemplate(Double.class,
-                                                                       "function('ST_DistanceSphere', {0}, {1})",
-                                                                       place.location,
-                                                                       location);
-    JPAQuery<Tuple> query;
 
-    query = sortStrategy.apply(qf, distanceSphere, sortOrder, filterValues);
+    NumberTemplate<Double> distance = Expressions.numberTemplate(Double.class,
+                                                                 "ST_Distance({0}, geography({1}))",
+                                                                 place.location,
+                                                                 location);
+
+    BooleanTemplate dwithin = Expressions.booleanTemplate("ST_DWithin({0}, geography({1}), {2})",
+                                                          place.location,
+                                                          location,
+                                                          maxDist);
+
+    JPAQuery<Tuple> query;
+    query = sortStrategy.apply(qf, distance, sortOrder, filterValues);
     query = filterStrategy.apply(query, filterValues); // return empty if filterValues is empty
-    query.where(distanceSphere.loe(maxDist));
+    query.where(dwithin.eq(true));
     query.offset(offset);
     query.limit(pageSize);
     return query.fetch();

--- a/backend/demo/src/main/java/com/_2cha/demo/place/service/PlaceService.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/place/service/PlaceService.java
@@ -42,7 +42,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.locationtech.jts.geom.Point;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Pageable;
@@ -140,7 +141,7 @@ public class PlaceService {
 
   public PlaceBriefWithDistanceResponse getPlaceBriefWithDistance(Long placeId, Double lat,
                                                                   Double lon, Integer summarySize) {
-    Point cur = GeomUtils.createPoint(lat, lon);
+    Point<G2D> cur = GeomUtils.createPoint(lat, lon);
     PlaceBriefWithDistanceResponse brief = placeQueryRepository.getPlaceBriefWithDistance(placeId,
                                                                                           cur,
                                                                                           fileStorageService.getBaseUrl());

--- a/backend/demo/src/main/java/com/_2cha/demo/review/controller/ReviewController.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/review/controller/ReviewController.java
@@ -25,7 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Point;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
 import org.springframework.data.domain.Pageable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -94,7 +95,7 @@ public class ReviewController {
   public CompletableFuture<ImageUrlWithSuggestionResponse> saveReviewImage(
       @RequestParam @ImageMime MultipartFile file)
       throws IOException {
-    Point point;
+    Point<G2D> point;
     byte[] imageBytes = file.getBytes();
     CompletableFuture<ImageSavedResponse> save = imageUploadService.save(imageBytes, true);
     CompletableFuture<List<PlaceSuggestionResponse>> suggestion = completedFuture(

--- a/backend/demo/src/main/java/com/_2cha/demo/util/GeomUtils.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/util/GeomUtils.java
@@ -2,24 +2,23 @@ package com._2cha.demo.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.PrecisionModel;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Geometries;
+import org.geolatte.geom.Point;
+import org.geolatte.geom.crs.CoordinateReferenceSystems;
 
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GeomUtils {
 
-  private static GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
-
-  public static Point createPoint(Double latitude, Double longitude) {
-    return geometryFactory.createPoint(new Coordinate(longitude, latitude));
+  public static Point<G2D> createPoint(Double latitude, Double longitude) {
+    return Geometries.mkPoint(new G2D(longitude, latitude),
+                              CoordinateReferenceSystems.WGS84);
   }
 
-  public static Double lat(Point point) {return point.getY();}
+  public static Double lat(Point<G2D> point) {return point.getPosition().getCoordinate(1);}
 
-  public static Double lon(Point point) {return point.getX();}
+  public static Double lon(Point<G2D> point) {return point.getPosition().getCoordinate(0);}
 
   public static Double calcDistance(Double lat1, Double lon1, Double lat2, Double lon2, char unit) {
     Double theta = lon1 - lon2;

--- a/backend/demo/src/main/java/com/_2cha/demo/util/ImageUtils.java
+++ b/backend/demo/src/main/java/com/_2cha/demo/util/ImageUtils.java
@@ -16,7 +16,8 @@ import net.coobird.thumbnailator.tasks.UnsupportedFormatException;
 import org.apache.tika.Tika;
 import org.apache.tika.mime.MimeTypeException;
 import org.apache.tika.mime.MimeTypes;
-import org.locationtech.jts.geom.Point;
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -52,7 +53,7 @@ public class ImageUtils {
     return actualExt;
   }
 
-  public static Point getGeoPoint(byte[] imageBytes) {
+  public static Point<G2D> getGeoPoint(byte[] imageBytes) {
     try (InputStream inputStream = new ByteArrayInputStream(imageBytes)) {
       Metadata metadata = ImageMetadataReader.readMetadata(inputStream);
       GeoLocation geoLocation;

--- a/backend/demo/src/main/resources/application-prod.yaml
+++ b/backend/demo/src/main/resources/application-prod.yaml
@@ -22,3 +22,6 @@ spring:
           type: elasticsearch
           uris: ${ELASTICSEARCH_URI}  # ex: http://localhost:9200
           analysis.configurer: class:com._2cha.demo.recommendation.config.ElasticsearchAnalyzerConf
+  sql:
+    init:
+      mode: never

--- a/backend/demo/src/main/resources/schema.sql
+++ b/backend/demo/src/main/resources/schema.sql
@@ -1,0 +1,2 @@
+-- spatial index for place location
+create index if not exists place_location_idx on place using gist (location);


### PR DESCRIPTION
- Spatial Index 적용을 위해, `ST_Distance`를 이용한 거리 비교에서 `ST_DWithin` 사용으로 교체
- `Place#location` 컬럼 타입 변경(to `geography`)으로 인한 Spatial 쿼리 수정
- `Point` 타입 교체 (`jts` to `geolatte`)
